### PR TITLE
feat: define and implement failure behaviour across the pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -464,3 +464,48 @@ The per-newspaper verbatim breakpoint (all prompts included raw without summaris
 16. **One Gemini call per newspaper per day** — Cost scales linearly with active newspapers, not with prompt volume. At ~$3 per newspaper edition, 6 newspapers cost ~$18/day.
 
 17. **Overlap between newspapers is a feature** — When multiple newspapers receive the same prompt via shared category subscriptions, they produce genuinely distinct articles because each sees a different prompt pool composition and has a different editorial lens.
+
+## Failure Behaviour
+
+This section documents the defined failure behaviour at each stage of the pipeline.
+
+### Ingestion API
+
+| Failure point | Behaviour |
+|---|---|
+| Braintree webhook duplicate delivery | Idempotency check on `braintree_transaction_id`. Duplicate webhooks return 200 without re-processing. |
+| Categoriser fails (e.g. Gemini API error) | Payment ref and raw prompt are committed to the DB with status `categorisation_failed`. No `categorised_prompts` rows are created. The prompt is excluded from the next morning batch (only `accepted` prompts are fetched). Recovery: re-run categorisation against the saved prompt text. |
+| Database unreachable during webhook | FastAPI returns 500. The DB session is explicitly rolled back. Braintree will retry the webhook; the idempotency check prevents double-processing on successful retry. |
+| Partial DB write (prompt flushed, categorisation fails before commit) | The session is rolled back — no partial state persists. SQLAlchemy's session close triggers implicit rollback; `get_db()` also calls explicit rollback on error. |
+
+### Newsroom Director
+
+| Failure point | Behaviour |
+|---|---|
+| Single newspaper Gemini call fails (after retries) | That newspaper is skipped. Other newspapers continue to generate. The edition is published with whichever newspapers succeeded. |
+| All newspaper Gemini calls fail | `articles` dict is empty. No edition is created. Prompts remain `accepted` and are retried on the next morning run. |
+| Vertex AI context cache creation fails | Falls back to uncached generation for all newspapers. The pipeline continues without interruption. |
+| Coherence validation Gemini call fails (parse error) | Falls back to accepting all prompts in the failing batch — we prefer false positives over silently dropping paid prompts. |
+| WorldLedger mutation fails (LLM parse error or exception) | The ledger mutation is skipped for that day. The edition is still published. The WorldLedger is not updated; the next day's run starts from the previous ledger state. |
+| R2 write fails | The DB session is rolled back. No edition is recorded and prompts remain `accepted`. The pipeline exits with an error (Cloud Run Job reports failure and triggers alerting). Prompts are retried on the next morning run. Gemini generation cost is lost. |
+| Database unreachable during batch | The pipeline exits with an error. Cloud Run Job reports failure. No prompts are marked processed; they are retried on the next morning run. |
+| Vertex AI context cache deletion fails | Already safe — `VertexAIStrategy.delete_cache()` swallows the exception and logs a warning. Stale cache incurs idle billing until Vertex AI expires it. |
+
+### Morning Batch — Pipeline-Level Decisions
+
+- **If the batch fails entirely**: Nothing is published. Prompts stay `accepted` and are retried the next morning.
+- **If some newspapers fail**: The edition is published with the newspapers that succeeded. Partial editions are acceptable.
+- **Failed prompts (coherence rejection)**: Marked `rejected`. Payment is consumed — users paid for the attempt.
+- **Failed prompts (pipeline error)**: Left as `accepted`. Retried on the next morning run.
+- **No prompts for a newspaper**: That newspaper produces no edition for the day. This is normal; not every newspaper covers every topic.
+
+### Frontend
+
+| Failure point | Behaviour |
+|---|---|
+| Quote API unavailable | Error message shown below the orb. Submit button stays disabled. User can retry by modifying the prompt. |
+| Braintree Drop-in fails to initialise (client-token endpoint down) | Error message shown in the payment form. Pay button stays disabled. User can navigate back and retry. |
+| Payment tokenisation fails | Error message shown in the payment form. User can retry without leaving the page. |
+| Render crash in `PromptFlow` | `ErrorBoundary` shows a "Something went wrong" message with a retry button. The crash is reported to Sentry. |
+
+> **Note:** `ErrorBoundary` catches errors in React component render and lifecycle methods. It does **not** catch errors in async event handlers. Async errors (quote fetch, Braintree init, payment request) are handled individually in `useQuote` and `useBraintree` hooks and surfaced via component state.

--- a/apps/ingestion-api/ingestion_api/database.py
+++ b/apps/ingestion-api/ingestion_api/database.py
@@ -18,6 +18,9 @@ def get_db():
     db = SessionLocal()
     try:
         yield db
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()
 

--- a/apps/ingestion-api/ingestion_api/main.py
+++ b/apps/ingestion-api/ingestion_api/main.py
@@ -1,5 +1,7 @@
 """Imbryk Ingestion API — prompts, payments, and editions."""
 
+import logging
+
 import sentry_sdk
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -37,6 +39,8 @@ from ingestion_api.schemas import (
     WebhookPayload,
 )
 from ingestion_api.taxonomy import route_prompt
+
+logger = logging.getLogger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 
@@ -141,6 +145,32 @@ async def braintree_webhook(
     amount = float(transaction.get("amount", 0))
     prompt_text = transaction.get("custom_fields", {}).get("prompt_text", "")
 
+    # Idempotency: Braintree may redeliver the same webhook on timeout/retry.
+    # Return 200 without re-processing if we've already handled this transaction.
+    existing_payment = (
+        db.query(PaymentRef)
+        .filter_by(braintree_transaction_id=transaction_id)
+        .first()
+    )
+    if existing_payment is not None:
+        existing_prompt = (
+            db.query(Prompt).filter_by(payment_ref=transaction_id).first()
+        )
+        if existing_prompt is not None:
+            existing_cats = [
+                cp.category_id
+                for cp in db.query(CategorisedPrompt)
+                .filter_by(prompt_id=existing_prompt.id)
+                .all()
+            ]
+            routing = route_prompt(existing_cats)
+            return PromptAcceptedResponse(
+                prompt_id=existing_prompt.id,
+                status=existing_prompt.status,
+                categories=existing_cats,
+                newspapers_reached=len(routing),
+            )
+
     # Save payment ref
     payment = PaymentRef(
         braintree_transaction_id=transaction_id,
@@ -159,10 +189,21 @@ async def braintree_webhook(
     db.add(prompt)
     db.flush()
 
-    # Categorise and save
-    categories = categoriser.categorise(prompt_text)
-    for cat_id in categories:
-        db.add(CategorisedPrompt(prompt_id=prompt.id, category_id=cat_id))
+    # Categorise and save. If the categoriser fails (e.g. Gemini API error),
+    # we still commit the payment and prompt so the record is not lost.
+    # The prompt is marked 'categorisation_failed' and excluded from the next
+    # batch run; manual recovery can re-run categorisation against the saved text.
+    categories: list[str] = []
+    try:
+        categories = categoriser.categorise(prompt_text)
+        for cat_id in categories:
+            db.add(CategorisedPrompt(prompt_id=prompt.id, category_id=cat_id))
+    except Exception:
+        logger.exception(
+            "Categorisation failed for prompt %s; saving with 'categorisation_failed' status",
+            prompt.id,
+        )
+        prompt.status = "categorisation_failed"
 
     db.commit()
 
@@ -170,7 +211,7 @@ async def braintree_webhook(
 
     return PromptAcceptedResponse(
         prompt_id=prompt.id,
-        status="accepted",
+        status=prompt.status,
         categories=categories,
         newspapers_reached=len(routing),
     )

--- a/apps/newsroom-director/newsroom_director/main.py
+++ b/apps/newsroom-director/newsroom_director/main.py
@@ -120,9 +120,16 @@ def run_morning_press(
         # Step 4: Serialize WorldLedger to synopsis
         synopsis = serialize_ledger_to_synopsis(ledger)
 
-        # Step 4b: Create context cache for synopsis (shared across newspapers)
+        # Step 4b: Create context cache for synopsis (shared across newspapers).
+        # Falls back to uncached generation if cache creation fails.
         if enable_caching:
-            cached_content = gen.create_cache(synopsis)
+            try:
+                cached_content = gen.create_cache(synopsis)
+            except Exception:
+                logger.warning(
+                    "Context cache creation failed, falling back to uncached generation",
+                    exc_info=True,
+                )
 
         # Step 5: Coherence validation — filter prompts against world state
         if enable_validation:
@@ -147,7 +154,9 @@ def run_morning_press(
             for route in routes:
                 newspaper_prompts[route.newspaper_id].append(pr)
 
-        # Step 7: For each newspaper, distill and generate
+        # Step 7: For each newspaper, distill and generate.
+        # Failures for individual newspapers are isolated — a single Gemini error
+        # skips that paper but allows the remaining newspapers to proceed.
         articles: dict[str, str] = {}
         for persona in NEWSPAPER_PERSONAS:
             prompts_for_paper = newspaper_prompts.get(persona.id, [])
@@ -163,46 +172,53 @@ def run_morning_press(
                 },
             )
 
-            # Convert to distillation Prompt objects
-            dist_prompts = [
-                DistillationPrompt(
-                    text=pr.text,
-                    payment_amount=pr.payment_amount,
-                    prompt_id=pr.prompt_id,
+            try:
+                # Convert to distillation Prompt objects
+                dist_prompts = [
+                    DistillationPrompt(
+                        text=pr.text,
+                        payment_amount=pr.payment_amount,
+                        prompt_id=pr.prompt_id,
+                    )
+                    for pr in prompts_for_paper
+                ]
+
+                # Run distillation pipeline
+                budgeted = pipeline.run(dist_prompts)
+                digests_text = pipeline.serialize_all(budgeted)
+
+                # Build the user prompt with cluster digests for this newspaper
+                user_prompt = persona.system_prompt_template.replace(
+                    "{{WORLD_LEDGER_SYNOPSIS}}", synopsis
+                ).replace("{{CLUSTER_DIGESTS}}", digests_text)
+
+                # Call LLM — use cached generation when cache is available
+                gen_start = time.monotonic()
+                if cached_content is not None:
+                    article = gen.generate_with_cache(
+                        cached_content, user_prompt, persona.model_tier
+                    )
+                else:
+                    article = gen.generate(user_prompt, persona.model_tier)
+                gen_ms = int((time.monotonic() - gen_start) * 1000)
+
+                logger.info(
+                    "Article generated",
+                    extra={
+                        "step": "generated",
+                        "newspaper_id": persona.id,
+                        "model_tier": persona.model_tier,
+                        "latency_ms": gen_ms,
+                    },
                 )
-                for pr in prompts_for_paper
-            ]
 
-            # Run distillation pipeline
-            budgeted = pipeline.run(dist_prompts)
-            digests_text = pipeline.serialize_all(budgeted)
+                articles[persona.id] = article
 
-            # Build the user prompt with cluster digests for this newspaper
-            user_prompt = persona.system_prompt_template.replace(
-                "{{WORLD_LEDGER_SYNOPSIS}}", synopsis
-            ).replace("{{CLUSTER_DIGESTS}}", digests_text)
-
-            # Call LLM — use cached generation when cache is available
-            gen_start = time.monotonic()
-            if cached_content is not None:
-                article = gen.generate_with_cache(
-                    cached_content, user_prompt, persona.model_tier
+            except Exception:
+                logger.exception(
+                    "Failed to generate articles for newspaper %s, skipping",
+                    persona.id,
                 )
-            else:
-                article = gen.generate(user_prompt, persona.model_tier)
-            gen_ms = int((time.monotonic() - gen_start) * 1000)
-
-            logger.info(
-                "Article generated",
-                extra={
-                    "step": "generated",
-                    "newspaper_id": persona.id,
-                    "model_tier": persona.model_tier,
-                    "latency_ms": gen_ms,
-                },
-            )
-
-            articles[persona.id] = article
 
         # Step 8: Run Curator synthesis
         if articles:


### PR DESCRIPTION
Closes #5

## Summary

Adds missing error handling across the pipeline and documents all failure decisions in ARCHITECTURE.md.

## Changes

**Ingestion API**
- Add idempotency check on Braintree webhook (duplicate delivery returns 200 without re-processing)
- Isolate categoriser failures — payment + prompt committed with status `categorisation_failed` so the record is not lost when Gemini is unreachable
- Add explicit `db.rollback()` in `get_db()` on exception

**Newsroom Director**
- Per-newspaper generation wrapped in try/except; one Gemini failure skips that paper without aborting the batch
- Context cache creation failure falls back to uncached generation

**ARCHITECTURE.md**
- Add Failure Behaviour section documenting all defined failure decisions

Generated with [Claude Code](https://claude.ai/code)