### PR TITLE
fix: recover newspaper generation from LLM field name deviations

### DIFF
--- a/apps/gazette/src/_data/lib/loadEditions.js
+++ b/apps/gazette/src/_data/lib/loadEditions.js
@@ -29,6 +29,35 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const R2_PUBLIC_URL = process.env.R2_PUBLIC_URL || '';
 
 /**
+ * Static mapping from newspaper ID to display name.
+ * Derived from data/personas.json — update if personas change.
+ */
+const NEWSPAPER_NAMES = {
+  sovereign: 'The Sovereign',
+  aspirant: 'The Aspirant',
+  owner: 'The Owner',
+  moralist: 'The Moralist',
+  radical: 'The Radical',
+  hedonist: 'The Hedonist',
+  curator: 'The Curator',
+};
+
+/**
+ * Strip markdown code fences from a string, if present.
+ * Handles ```json ... ``` or ``` ... ``` wrappers that LLMs occasionally emit.
+ */
+function stripMarkdownFences(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('```')) return trimmed;
+  const lines = trimmed.split('\n');
+  const inner = lines.slice(1); // remove opening fence line (```json or ```)
+  if (inner.length > 0 && inner[inner.length - 1].trim() === '```') {
+    inner.pop(); // remove closing fence
+  }
+  return inner.join('\n');
+}
+
+/**
  * Transform an R2 edition JSON into the gazette template shape.
  *
  * R2 shape:
@@ -52,8 +81,12 @@ export async function transformR2Edition(r2Edition, sourceUrl) {
   )) {
     let parsed;
     try {
-      parsed =
-        typeof rawContent === 'string' ? JSON.parse(rawContent) : rawContent;
+      if (typeof rawContent === 'string') {
+        const cleaned = stripMarkdownFences(rawContent);
+        parsed = JSON.parse(cleaned);
+      } else {
+        parsed = rawContent;
+      }
     } catch (err) {
       await captureLoadError(
         sourceUrl,
@@ -71,9 +104,16 @@ export async function transformR2Edition(r2Edition, sourceUrl) {
         parsed.newspaper_id = newspaperId;
       }
 
+      // Inject newspaper_name from the static mapping when the LLM omits it.
+      if (!parsed.newspaper_name && NEWSPAPER_NAMES[newspaperId]) {
+        parsed.newspaper_name = NEWSPAPER_NAMES[newspaperId];
+      }
+
       // Normalise field name variants produced by LLMs that deviate from the schema.
       // The LLM prompt specifies exact names, but flash-tier models occasionally use
-      // alternatives (e.g. "title"/"content" instead of "headline"/"body").
+      // alternatives (e.g. "title"/"content" instead of "headline"/"body",
+      // "inBrief"/"inBriefs" instead of "in_brief", "editorsNote"/"editorNote"
+      // instead of "editors_note").
       if (Array.isArray(parsed.articles)) {
         parsed.articles = parsed.articles.map((a) => ({
           ...a,
@@ -81,6 +121,20 @@ export async function transformR2Edition(r2Edition, sourceUrl) {
           body: a.body ?? a.content ?? a.text ?? undefined,
         }));
       }
+
+      // Normalise in_brief key variants
+      if (!parsed.in_brief) {
+        parsed.in_brief = parsed.inBrief ?? parsed.inBriefs;
+      }
+
+      // Normalise editors_note key variants
+      if (!parsed.editors_note) {
+        const alt = parsed.editorsNote ?? parsed.editorNote ?? parsed.editor_note;
+        if (typeof alt === 'string') {
+          parsed.editors_note = alt;
+        }
+      }
+
       if (Array.isArray(parsed.in_brief)) {
         parsed.in_brief = parsed.in_brief.map((item) => ({
           ...item,

--- a/apps/newsroom-director/newsroom_director/main.py
+++ b/apps/newsroom-director/newsroom_director/main.py
@@ -291,33 +291,45 @@ def run_morning_press(
             parsed = _try_parse_edition_json(content)
             if parsed is None:
                 continue
+
+            # Always re-serialize to clean JSON (strips any markdown fences
+            # that the LLM may have emitted) before attempting image generation.
+            # This ensures R2 always receives valid JSON regardless of whether
+            # image generation succeeds or fails.
+            articles[newspaper_id] = json.dumps(parsed, ensure_ascii=False)
+
             article_list = parsed.get("articles", [])
             front_page_prompt = parsed.get("frontPageImagePrompt")
 
-            result = generate_images_for_newspaper(
-                newspaper_id=newspaper_id,
-                articles=article_list,
-                front_page_image_prompt=front_page_prompt,
-                imagen_client=img_client,
-                storage=store,
-                edition_id=str(
-                    datetime.now(timezone.utc).strftime("%Y-%m-%d")
-                ),
-            )
+            try:
+                result = generate_images_for_newspaper(
+                    newspaper_id=newspaper_id,
+                    articles=article_list,
+                    front_page_image_prompt=front_page_prompt,
+                    imagen_client=img_client,
+                    storage=store,
+                    edition_id=str(
+                        datetime.now(timezone.utc).strftime("%Y-%m-%d")
+                    ),
+                )
 
-            # Embed image URLs into articles
-            for idx, url in result.article_image_urls.items():
-                if idx < len(article_list):
-                    article_list[idx]["image_url"] = url
+                # Embed image URLs into articles
+                for idx, url in result.article_image_urls.items():
+                    if idx < len(article_list):
+                        article_list[idx]["image_url"] = url
+                        image_counts += 1
+                if result.hero_image_url:
+                    parsed["heroImageUrl"] = result.hero_image_url
                     image_counts += 1
-            if result.hero_image_url:
-                parsed["heroImageUrl"] = result.hero_image_url
-                image_counts += 1
 
-            # Re-serialize back to JSON string
-            articles[newspaper_id] = json.dumps(
-                parsed, ensure_ascii=False
-            )
+                # Re-serialize with image URLs embedded
+                articles[newspaper_id] = json.dumps(parsed, ensure_ascii=False)
+            except Exception:
+                logger.exception(
+                    "Image generation failed for newspaper %s, "
+                    "continuing without images",
+                    newspaper_id,
+                )
 
         logger.info(
             "Image generation complete",


### PR DESCRIPTION
Fixes #19

Two-layer fix for gazette build failures caused by LLM output not matching the expected schema.

**gazette / loadEditions.js:**
- Strip markdown code fences before JSON.parse
- Inject newspaper_name from static ID→name mapping when omitted
- Normalise inBrief/inBriefs → in_brief
- Normalise editorsNote/editorNote → editors_note

**newsroom-director / main.py:**
- Always re-serialize to clean JSON before image generation
- Wrap image generation in try/except to prevent loss of cleaned content

Generated with [Claude Code](https://claude.ai/code)