### PR TITLE
feat: improve gazette layout — anchors, article nav, fonts, archive

### DIFF
--- a/apps/gazette/src/_data/articlePages.js
+++ b/apps/gazette/src/_data/articlePages.js
@@ -71,6 +71,7 @@ export default async function () {
           allNewspaperIds,
           designTokens: tokens,
           cssVars,
+          googleFontsUrl: tokens?.googleFontsUrl || null,
         });
       }
     }

--- a/apps/gazette/src/_data/designTokens.js
+++ b/apps/gazette/src/_data/designTokens.js
@@ -13,6 +13,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Source Sans 3', sans-serif",
     borderStyle: '4px solid',
     borderStyleName: 'geometric',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Oswald:wght@400;700&family=Source+Sans+3:wght@400;600;700&display=swap',
   },
   aspirant: {
     primary: '#1a8a7d',
@@ -22,6 +24,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Merriweather Sans', sans-serif",
     borderStyle: '2px solid',
     borderStyleName: 'clean',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Libre+Franklin:wght@400;600;700&family=Merriweather+Sans:wght@400;700&display=swap',
   },
   owner: {
     primary: '#2c3e50',
@@ -31,6 +35,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Lora', serif",
     borderStyle: '1px solid',
     borderStyleName: 'rule',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Lora:ital,wght@0,400;0,700;1,400&display=swap',
   },
   sovereign: {
     primary: '#1b4332',
@@ -40,6 +46,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Source Serif 4', serif",
     borderStyle: '3px double',
     borderStyleName: 'ornate',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,700;1,400&family=Source+Serif+4:ital,wght@0,400;0,700;1,400&display=swap',
   },
   moralist: {
     primary: '#6c3483',
@@ -49,6 +57,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Nunito', sans-serif",
     borderStyle: '2px dashed',
     borderStyleName: 'traditional',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Vollkorn:ital,wght@0,400;0,700;1,400&family=Nunito:wght@400;700&display=swap',
   },
   hedonist: {
     primary: '#d4ac0d',
@@ -58,6 +68,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Inter', sans-serif",
     borderStyle: '2px dotted',
     borderStyleName: 'playful',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Inter:wght@400;600;700&display=swap',
   },
   curator: {
     primary: '#34495e',
@@ -67,6 +79,8 @@ const PERSONA_DESIGN_MAP = {
     fontBody: "'Inter', sans-serif",
     borderStyle: '1px solid',
     borderStyleName: 'neutral',
+    googleFontsUrl:
+      'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap',
   },
 };
 

--- a/apps/gazette/src/_data/newspaperPages.js
+++ b/apps/gazette/src/_data/newspaperPages.js
@@ -66,6 +66,7 @@ export default async function () {
         allNewspaperIds,
         designTokens: tokens,
         cssVars: toCSSCustomProperties(tokens),
+        googleFontsUrl: tokens?.googleFontsUrl || null,
       });
     }
   }

--- a/apps/gazette/src/_includes/article-nav.njk
+++ b/apps/gazette/src/_includes/article-nav.njk
@@ -9,22 +9,40 @@
 #}
 
 <nav class="article-nav" aria-label="Article navigation">
-  {% if prevArticle %}
-    <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/{{ prevArticle.slug }}/">
-      <span class="article-nav__label">← Previous</span>
-      {{ prevArticle.headline }}
-    </a>
-  {% else %}
-    <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/">
-      <span class="article-nav__label">←</span>
-      Back to {{ articleNewspaperName }}
-    </a>
-  {% endif %}
+  <div class="article-nav__inner">
 
-  {% if nextArticle %}
-    <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/{{ nextArticle.slug }}/" class="article-nav__next">
-      <span class="article-nav__label">Next →</span>
-      {{ nextArticle.headline }}
-    </a>
-  {% endif %}
+    <div class="article-nav__prev">
+      {% if prevArticle %}
+        <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/{{ prevArticle.slug }}/"
+           class="article-nav__link">
+          <span class="article-nav__arrow" aria-hidden="true">←</span>
+          <span class="article-nav__info">
+            <span class="article-nav__label">Previous</span>
+            <span class="article-nav__headline">{{ prevArticle.headline }}</span>
+          </span>
+        </a>
+      {% endif %}
+    </div>
+
+    <div class="article-nav__center">
+      <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/"
+         class="article-nav__back">
+        All articles
+      </a>
+    </div>
+
+    <div class="article-nav__next-col">
+      {% if nextArticle %}
+        <a href="/edition/{{ articleEditionDate }}/{{ articleNewspaperId }}/{{ nextArticle.slug }}/"
+           class="article-nav__link article-nav__link--next">
+          <span class="article-nav__info">
+            <span class="article-nav__label">Next</span>
+            <span class="article-nav__headline">{{ nextArticle.headline }}</span>
+          </span>
+          <span class="article-nav__arrow" aria-hidden="true">→</span>
+        </a>
+      {% endif %}
+    </div>
+
+  </div>
 </nav>

--- a/apps/gazette/src/_includes/article-preview.njk
+++ b/apps/gazette/src/_includes/article-preview.njk
@@ -11,8 +11,9 @@
 {% set truncateCount = previewTruncate if previewTruncate else 30 %}
 
 <a href="/edition/{{ previewEditionDate }}/{{ previewNewspaperId }}/{{ previewArticle.slug }}/"
+   id="{{ previewArticle.slug }}"
    class="article-preview{% if previewIsLead %} article-preview--lead{% endif %}">
-  <article id="{{ previewArticle.slug }}">
+  <article>
     {% if previewArticle.image_url %}
       <img src="{{ previewArticle.image_url }}"
            alt="{{ previewArticle.imagePrompt }}"
@@ -24,7 +25,10 @@
     <div class="article-preview__body">
       <h3 class="article-preview__title">{{ previewArticle.headline }}</h3>
       <p class="article-preview__excerpt">{{ previewArticle.body | truncateWords(truncateCount) }}</p>
-      <p class="article-preview__meta">{{ previewArticle.word_count }} words</p>
+      <p class="article-preview__meta">
+        {{ previewArticle.word_count }} words
+        <span class="article-preview__read-more" aria-hidden="true">Read article →</span>
+      </p>
     </div>
   </article>
 </a>

--- a/apps/gazette/src/_includes/front-page-card.njk
+++ b/apps/gazette/src/_includes/front-page-card.njk
@@ -8,7 +8,7 @@
 
 {% set leadHeadline = cardNewspaper.articles[0].headline if cardNewspaper.articles.length else "" %}
 
-<li>
+<li{% if cardId %} id="{{ cardId }}"{% endif %}>
   <a href="/edition/{{ cardEditionDate }}/{{ cardNewspaper.newspaper_id }}/"
      class="front-page-card"
      style="{{ cardPersona.cssVars if cardPersona else '' }}"

--- a/apps/gazette/src/_includes/layouts/base.njk
+++ b/apps/gazette/src/_includes/layouts/base.njk
@@ -34,10 +34,14 @@
 
   <!-- favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <!-- Google Fonts: per-newspaper heading & body fonts -->
+  <!-- Google Fonts: load only the fonts needed for this page -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  {% if googleFontsUrl %}
+  <link href="{{ googleFontsUrl }}" rel="stylesheet">
+  {% else %}
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;600;700&family=Libre+Franklin:wght@400;600;700&family=Lora:ital,wght@0,400;0,700;1,400&family=Merriweather+Sans:wght@400;700&family=Nunito:wght@400;700&family=Oswald:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&family=Poppins:wght@400;600;700&family=Source+Sans+3:wght@400;600;700&family=Source+Serif+4:ital,wght@0,400;0,700;1,400&family=Vollkorn:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  {% endif %}
   <link rel="stylesheet" href="/css/style.css">
 
   <!-- JSON-LD: WebSite (every page) -->

--- a/apps/gazette/src/archive.njk
+++ b/apps/gazette/src/archive.njk
@@ -19,13 +19,23 @@ ogType: website
 </header>
 
 {% if editions.length %}
-  <ul class="edition-list" role="list">
+  <ul class="archive-grid" role="list">
     {% for edition in editions %}
-      <li class="edition-list-item">
-        <a href="/edition/{{ edition.date }}/">
-          <time datetime="{{ edition.date | dateISO }}">{{ edition.date | dateDisplay }}</time>
+      <li class="archive-card">
+        <a href="/edition/{{ edition.date }}/" class="archive-card__date-link">
+          <time datetime="{{ edition.date | dateISO }}" class="archive-card__date">{{ edition.date | dateDisplay }}</time>
         </a>
-        — {{ edition.newspapers.length }} newspaper{{ "s" if edition.newspapers.length != 1 }}
+        <ul class="archive-card__newspapers" role="list">
+          {% for newspaper in edition.newspapers %}
+            {% set persona = personas.newspapers | findPersona(newspaper.newspaper_id) %}
+            <li>
+              <a href="/edition/{{ edition.date }}/{{ newspaper.newspaper_id }}/"
+                 class="archive-card__np-link">
+                {{ persona.paperName if persona else newspaper.newspaper_name }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
       </li>
     {% endfor %}
   </ul>

--- a/apps/gazette/src/article.njk
+++ b/apps/gazette/src/article.njk
@@ -13,6 +13,7 @@ eleventyComputed:
   ogDescription: "{{ ap.article.body | truncateChars(200) }}"
   ogImage: "{% if ap.article.image_url %}{{ ap.article.image_url }}{% elif ap.heroImageUrl %}{{ ap.heroImageUrl }}{% endif %}"
   ogImageAlt: "{{ ap.article.imagePrompt | default(ap.article.headline) }}"
+  googleFontsUrl: "{{ ap.googleFontsUrl }}"
 ---
 
 {% set persona = personas.newspapers | findPersona(ap.newspaperId) %}
@@ -54,8 +55,11 @@ eleventyComputed:
 
 <div class="newspaper" style="{{ ap.cssVars }}">
 
-  <article>
-    <h1 class="article-full__title">{{ ap.article.headline }}</h1>
+  <article id="{{ ap.slug }}">
+    <h1 class="article-full__title">
+      {{ ap.article.headline }}
+      <a href="#{{ ap.slug }}" class="anchor-link" aria-label="Permalink to this article">#</a>
+    </h1>
 
     <p class="article-full__meta">
       {{ ap.newspaperName }} · {{ ap.editionDate | dateDisplay }} · {{ ap.article.word_count }} words

--- a/apps/gazette/src/css/style.css
+++ b/apps/gazette/src/css/style.css
@@ -545,6 +545,44 @@ main:has(.newspaper) {
   scroll-margin-top: var(--space-xl);
 }
 
+/* === Anchor Permalink Links === */
+.anchor-link {
+  display: inline-block;
+  margin-left: 0.35em;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  font-size: 0.7em;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  vertical-align: middle;
+}
+
+:is(h1, h2, h3):hover .anchor-link,
+:is(h1, h2, h3):focus-within .anchor-link,
+.anchor-link:focus-visible {
+  opacity: 1;
+}
+
+.anchor-link:hover {
+  color: var(--color-accent);
+  opacity: 1;
+}
+
+/* === Section Label === */
+.section-label {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  border-bottom: var(--np-border-style, 1px solid) var(--np-primary, var(--color-border-light));
+  padding-bottom: var(--space-sm);
+  margin-bottom: var(--space-lg);
+}
+
 /* === Breadcrumb === */
 .breadcrumb {
   margin-bottom: var(--space-sm);
@@ -768,6 +806,21 @@ main:has(.newspaper) {
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
   opacity: 0.7;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.article-preview__read-more {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--np-primary, var(--color-accent));
+  opacity: 1;
+  margin-left: auto;
 }
 
 /* Lead article — full width with prominent styling */
@@ -818,6 +871,128 @@ main:has(.newspaper) {
 
   .article-preview--lead .article-preview__excerpt {
     font-size: var(--type-base);
+  }
+}
+
+/* === Article Navigation === */
+.article-nav {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-xl);
+  border-top: var(--np-border-style, 1px solid) var(--np-primary, var(--color-border));
+}
+
+.article-nav__inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.article-nav__next-col {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.article-nav__link {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  text-decoration: none;
+  color: var(--np-primary, var(--color-link));
+  padding: var(--space-sm);
+  border-radius: var(--radius);
+  transition: background 0.15s;
+  max-width: 100%;
+}
+
+.article-nav__link:hover {
+  background: var(--np-secondary, var(--color-surface));
+  color: var(--np-primary, var(--color-link));
+}
+
+.article-nav__link--next {
+  text-align: right;
+  flex-direction: row-reverse;
+}
+
+.article-nav__arrow {
+  font-size: var(--type-lg);
+  line-height: 1.4;
+  flex-shrink: 0;
+  color: var(--np-primary, var(--color-accent));
+}
+
+.article-nav__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.article-nav__link--next .article-nav__info {
+  align-items: flex-end;
+}
+
+.article-nav__label {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.article-nav__headline {
+  font-family: var(--np-font-heading, 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.article-nav__back {
+  display: inline-block;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  color: var(--color-text-muted);
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.article-nav__back:hover {
+  color: var(--np-primary, var(--color-text));
+  border-color: var(--np-primary, var(--color-border));
+}
+
+@media (max-width: 35.9rem) {
+  .article-nav__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .article-nav__center {
+    order: -1;
+  }
+
+  .article-nav__next-col {
+    justify-content: flex-start;
+  }
+
+  .article-nav__link--next {
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .article-nav__link--next .article-nav__info {
+    align-items: flex-start;
   }
 }
 
@@ -908,6 +1083,66 @@ main:has(.newspaper) {
   padding: var(--space-xs) var(--space-sm);
   background: var(--color-border-light);
   border-radius: var(--radius);
+  color: var(--color-text-muted);
+}
+
+/* === Article Full Page === */
+.article-full__title {
+  font-family: var(--np-font-heading, 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  font-size: var(--type-2xl);
+  line-height: 1.2;
+  margin-bottom: var(--space-sm);
+}
+
+@media (min-width: 48rem) {
+  .article-full__title {
+    font-size: var(--type-3xl);
+  }
+}
+
+.article-full__meta {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-xl);
+}
+
+.article-full__body {
+  font-family: var(--np-font-body, Georgia, 'Times New Roman', Times, serif);
+  font-size: var(--type-base);
+  line-height: 1.75;
+  max-width: var(--measure);
+}
+
+.article-full__body p {
+  margin-bottom: var(--space-md);
+}
+
+.article-full__body h2,
+.article-full__body h3,
+.article-full__body h4 {
+  font-family: var(--np-font-heading, 'Helvetica Neue', Helvetica, Arial, sans-serif);
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-sm);
+}
+
+.article-full__body ul,
+.article-full__body ol {
+  padding-left: var(--space-lg);
+  margin-bottom: var(--space-md);
+}
+
+.article-full__body li {
+  margin-bottom: var(--space-xs);
+}
+
+.article-full__body blockquote {
+  border-left: 3px solid var(--np-primary, var(--color-accent));
+  padding: var(--space-sm) var(--space-md);
+  margin: var(--space-md) 0;
+  font-style: italic;
   color: var(--color-text-muted);
 }
 
@@ -1455,20 +1690,79 @@ main:has(.newspaper) {
   font-size: var(--type-sm);
 }
 
-/* === Archive === */
-.edition-list {
+/* === Archive Grid === */
+.archive-grid {
   list-style: none;
   padding: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-md);
 }
 
-.edition-list-item {
-  padding: var(--space-md) 0;
-  border-bottom: 1px solid var(--color-border-light);
+@media (min-width: 36rem) {
+  .archive-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
-.edition-list-item a {
+@media (min-width: 64rem) {
+  .archive-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.archive-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: var(--space-md) var(--space-lg);
+}
+
+.archive-card__date-link {
+  display: block;
+  text-decoration: none;
+}
+
+.archive-card__date {
+  display: block;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  font-weight: 600;
+  font-size: var(--type-base);
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: var(--space-sm);
+  padding-bottom: var(--space-sm);
+  border-bottom: 1px solid var(--color-border-light);
+  transition: color 0.15s;
+}
+
+.archive-card__date-link:hover .archive-card__date {
+  color: var(--color-accent);
+}
+
+.archive-card__newspapers {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+
+.archive-card__np-link {
+  display: inline-block;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: var(--type-xs);
+  padding: 2px var(--space-sm);
+  background: var(--color-border-light);
+  border-radius: var(--radius);
+  text-decoration: none;
+  color: var(--color-text-muted);
+  transition: background 0.15s, color 0.15s;
+}
+
+.archive-card__np-link:hover {
+  background: var(--color-accent);
+  color: #fff;
 }
 
 /* === Utilities === */

--- a/apps/gazette/src/edition.njk
+++ b/apps/gazette/src/edition.njk
@@ -27,6 +27,7 @@ eleventyComputed:
     {% set cardPersona = personas.newspapers | findPersona(newspaper.newspaper_id) %}
     {% set cardNewspaper = newspaper %}
     {% set cardEditionDate = edition.date %}
+    {% set cardId = newspaper.newspaper_id %}
     {% include "front-page-card.njk" %}
   {% endfor %}
 

--- a/apps/gazette/src/newspaper.njk
+++ b/apps/gazette/src/newspaper.njk
@@ -11,6 +11,7 @@ eleventyComputed:
   description: "{{ np.newspaperName }} — AI-powered perspective on how today's world-shaping events will unfold. {{ np.editionDate | dateDisplay }} edition."
   ogImage: "{% if np.heroImageUrl %}{{ np.heroImageUrl }}{% endif %}"
   ogImageAlt: "{{ np.newspaperName }} front page — {{ np.editionDate | dateDisplay }}"
+  googleFontsUrl: "{{ np.googleFontsUrl }}"
 ---
 
 {% set persona = personas.newspapers | findPersona(np.newspaperId) %}
@@ -49,7 +50,10 @@ eleventyComputed:
   {% endif %}
 
   <section id="articles" aria-labelledby="articles-heading">
-    <h2 id="articles-heading" class="visually-hidden">Articles</h2>
+    <h2 id="articles-heading" class="section-label">
+      Articles
+      <a href="#articles" class="anchor-link" aria-label="Link to Articles section">#</a>
+    </h2>
 
     <div class="newspaper-articles">
       {% for article in np.articles %}
@@ -73,7 +77,10 @@ eleventyComputed:
 
   {% if np.inBrief.length %}
     <section id="in-brief" class="in-brief" aria-labelledby="in-brief-heading">
-      <h2 id="in-brief-heading">In Brief</h2>
+      <h2 id="in-brief-heading">
+        In Brief
+        <a href="#in-brief" class="anchor-link" aria-label="Link to In Brief section">#</a>
+      </h2>
 
       {% for item in np.inBrief %}
         <div class="in-brief-item">
@@ -86,7 +93,10 @@ eleventyComputed:
 
   {% if np.editorsNote %}
     <aside id="editors-note" class="editors-note" aria-label="Editor's note">
-      <h2>Editor's Note</h2>
+      <h2>
+        Editor's Note
+        <a href="#editors-note" class="anchor-link" aria-label="Link to Editor's Note">#</a>
+      </h2>
       <p>{{ np.editorsNote }}</p>
     </aside>
   {% endif %}


### PR DESCRIPTION
Closes #18

Implements all layout improvements planned in issue #18:

- # anchor permalink links on articles, newspaper sections, and edition cards
- Redesigned article prev/next navigation with arrows, headlines, and "All articles" back link
- Fixed article body paragraph spacing (wrong CSS class was being targeted)
- Per-newspaper font loading: each page now loads only the 2 fonts it needs
- Archive redesigned as a responsive card grid with direct newspaper links
- Mobile-first throughout

Generated with [Claude Code](https://claude.ai/code)