### PR TITLE
security: fail-fast on missing secrets, disable docs in production

### DIFF
--- a/apps/ingestion-api/ingestion_api/config.py
+++ b/apps/ingestion-api/ingestion_api/config.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
 SENTRY_DSN = os.getenv("SENTRY_DSN", "")
 
 # Logging level
@@ -33,3 +35,32 @@ CORS_ALLOWED_ORIGINS = [
     for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:4200").split(",")
     if origin.strip()
 ]
+
+
+def validate_production_config() -> None:
+    """Raise RuntimeError if required env vars are missing in production.
+
+    Called at startup so the process refuses to start with a misconfigured
+    environment rather than silently degrading.
+    """
+    if ENVIRONMENT != "production":
+        return
+
+    errors: list[str] = []
+
+    if not STRIPE_SECRET_KEY:
+        errors.append("STRIPE_SECRET_KEY is required in production")
+    if not STRIPE_WEBHOOK_SECRET:
+        errors.append("STRIPE_WEBHOOK_SECRET is required in production")
+    if not VERTEX_PROJECT:
+        errors.append("VERTEX_PROJECT is required in production")
+    if "sqlite" in DATABASE_URL.lower():
+        errors.append(
+            "SQLite is not allowed in production; set DATABASE_URL to a PostgreSQL URL"
+        )
+
+    if errors:
+        raise RuntimeError(
+            "Missing required production configuration:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )

--- a/apps/ingestion-api/ingestion_api/main.py
+++ b/apps/ingestion-api/ingestion_api/main.py
@@ -16,6 +16,7 @@ from starlette.responses import JSONResponse
 from ingestion_api.categoriser import CategoriserStrategy, StubCategoriser
 from ingestion_api.config import (
     CORS_ALLOWED_ORIGINS,
+    ENVIRONMENT,
     RATE_LIMIT_QUOTE,
     SENTRY_DSN,
     STRIPE_SECRET_KEY,
@@ -23,6 +24,7 @@ from ingestion_api.config import (
     VERTEX_LOCATION,
     VERTEX_PROJECT,
     _log_level_int,
+    validate_production_config,
 )
 
 if SENTRY_DSN:
@@ -64,7 +66,15 @@ logger = logging.getLogger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 
-app = FastAPI(title="Imbryk Ingestion API", version="0.2.0")
+_docs_url = None if ENVIRONMENT == "production" else "/docs"
+_redoc_url = None if ENVIRONMENT == "production" else "/redoc"
+
+app = FastAPI(
+    title="Imbryk Ingestion API",
+    version="0.2.0",
+    docs_url=_docs_url,
+    redoc_url=_redoc_url,
+)
 app.state.limiter = limiter
 
 app.add_middleware(
@@ -78,6 +88,7 @@ app.add_middleware(
 @app.on_event("startup")
 async def startup_event():
     """Log API startup for visibility in Cloud Logging & Sentry."""
+    validate_production_config()
     configure_stripe()
     if not STRIPE_SECRET_KEY:
         logger.error(


### PR DESCRIPTION
Implements the mitigations from #33:

- Add `ENVIRONMENT` config var (defaults to `development`)
- Add `validate_production_config()` that raises `RuntimeError` if `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `VERTEX_PROJECT` are missing or `DATABASE_URL` uses SQLite when `ENVIRONMENT=production`
- Call `validate_production_config()` in the startup event so the process refuses to start rather than silently degrading
- Disable `/docs` and `/redoc` endpoints when `ENVIRONMENT=production`

Fixes #33

Generated with [Claude Code](https://claude.ai/code)