### PR TITLE
security: enforce quote expiry and limit checkout attempts

### DIFF
--- a/apps/ingestion-api/alembic/versions/007_add_quote_expiry_fields.py
+++ b/apps/ingestion-api/alembic/versions/007_add_quote_expiry_fields.py
@@ -1,0 +1,33 @@
+"""Add checkout_attempts to prompts for quote expiry enforcement.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-03-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007"
+down_revision: Union[str, None] = "006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "prompts",
+        sa.Column(
+            "checkout_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("prompts") as batch_op:
+        batch_op.drop_column("checkout_attempts")

--- a/apps/ingestion-api/ingestion_api/config.py
+++ b/apps/ingestion-api/ingestion_api/config.py
@@ -22,6 +22,12 @@ WEIGHT_MULTIPLIER_MAX = 100
 
 RATE_LIMIT_QUOTE = os.getenv("RATE_LIMIT_QUOTE", "10/minute")
 
+# Quote expiry — reject checkout for quotes older than this many minutes.
+QUOTE_TTL_MINUTES: int = int(os.getenv("QUOTE_TTL_MINUTES", "15"))
+
+# Maximum number of Stripe checkout sessions that may be created per quote.
+QUOTE_MAX_CHECKOUT_ATTEMPTS: int = int(os.getenv("QUOTE_MAX_CHECKOUT_ATTEMPTS", "3"))
+
 # Vertex AI — set VERTEX_PROJECT to activate GeminiFlashCategoriser
 VERTEX_PROJECT = os.getenv("VERTEX_PROJECT", "")
 VERTEX_LOCATION = os.getenv("VERTEX_LOCATION", "global")

--- a/apps/ingestion-api/ingestion_api/main.py
+++ b/apps/ingestion-api/ingestion_api/main.py
@@ -1,6 +1,7 @@
 """Imbryk Ingestion API — prompts, payments, and editions."""
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 import sentry_sdk.integrations.logging
@@ -16,6 +17,8 @@ from starlette.responses import JSONResponse
 from ingestion_api.categoriser import CategoriserStrategy, StubCategoriser
 from ingestion_api.config import (
     CORS_ALLOWED_ORIGINS,
+    QUOTE_MAX_CHECKOUT_ATTEMPTS,
+    QUOTE_TTL_MINUTES,
     RATE_LIMIT_QUOTE,
     SENTRY_DSN,
     STRIPE_SECRET_KEY,
@@ -214,6 +217,34 @@ async def create_checkout_session(
             status_code=409,
             content={"detail": f"Quote already processed (status={prompt.status})"},
         )
+
+    # Reject expired quotes — prevent price-lock exploitation with stale quotes.
+    quote_age = datetime.now(timezone.utc) - prompt.created_at.replace(tzinfo=timezone.utc)
+    if quote_age > timedelta(minutes=QUOTE_TTL_MINUTES):
+        logger.warning(
+            "Expired quote checkout attempt: quote_id=%s age=%s",
+            body.quote_id,
+            quote_age,
+        )
+        return JSONResponse(
+            status_code=410,
+            content={"detail": f"Quote has expired (quotes are valid for {QUOTE_TTL_MINUTES} minutes)"},
+        )
+
+    # Reject if too many checkout sessions have already been created for this quote.
+    if prompt.checkout_attempts >= QUOTE_MAX_CHECKOUT_ATTEMPTS:
+        logger.warning(
+            "Max checkout attempts reached: quote_id=%s attempts=%d",
+            body.quote_id,
+            prompt.checkout_attempts,
+        )
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Too many checkout attempts for this quote"},
+        )
+
+    # Increment checkout attempt counter before creating the Stripe session.
+    prompt.checkout_attempts += 1
 
     # Base amount comes from the DB — tamper-proof.
     base_amount = prompt.amount

--- a/apps/ingestion-api/ingestion_api/models.py
+++ b/apps/ingestion-api/ingestion_api/models.py
@@ -35,6 +35,9 @@ class Prompt(Base):
     status: Mapped[str] = mapped_column(
         String(32), nullable=False, default="quoted"
     )
+    checkout_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow
     )


### PR DESCRIPTION
Fixes #30

Adds quote TTL enforcement (15 min by default) and a per-quote checkout attempt cap (3 by default) to close the price-lock exploit and limit Stripe API abuse.

- New `QUOTE_TTL_MINUTES` and `QUOTE_MAX_CHECKOUT_ATTEMPTS` config constants (env-overridable)
- New `checkout_attempts` column on `prompts` (migration 007)
- Checkout endpoint returns 410 for expired quotes and 429 when attempt limit is reached

Generated with [Claude Code](https://claude.ai/code)