### PR TITLE
security: tighten quote rate limit and add expired-quote cleanup

### DIFF
--- a/apps/ingestion-api/ingestion_api/config.py
+++ b/apps/ingestion-api/ingestion_api/config.py
@@ -20,7 +20,11 @@ PROMPT_MAX_LENGTH = 2000
 WEIGHT_MULTIPLIER_MIN = 1
 WEIGHT_MULTIPLIER_MAX = 100
 
-RATE_LIMIT_QUOTE = os.getenv("RATE_LIMIT_QUOTE", "10/minute")
+RATE_LIMIT_QUOTE = os.getenv("RATE_LIMIT_QUOTE", "3/minute")
+
+# Quote expiry: orphaned 'quoted' rows older than this are purged automatically.
+QUOTE_EXPIRY_SECONDS = int(os.getenv("QUOTE_EXPIRY_SECONDS", "3600"))  # 1 hour
+QUOTE_CLEANUP_INTERVAL_SECONDS = int(os.getenv("QUOTE_CLEANUP_INTERVAL_SECONDS", "300"))  # 5 min
 
 # Vertex AI — set VERTEX_PROJECT to activate GeminiFlashCategoriser
 VERTEX_PROJECT = os.getenv("VERTEX_PROJECT", "")

--- a/apps/ingestion-api/ingestion_api/main.py
+++ b/apps/ingestion-api/ingestion_api/main.py
@@ -1,6 +1,8 @@
 """Imbryk Ingestion API — prompts, payments, and editions."""
 
+import asyncio
 import logging
+from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 import sentry_sdk.integrations.logging
@@ -16,6 +18,8 @@ from starlette.responses import JSONResponse
 from ingestion_api.categoriser import CategoriserStrategy, StubCategoriser
 from ingestion_api.config import (
     CORS_ALLOWED_ORIGINS,
+    QUOTE_CLEANUP_INTERVAL_SECONDS,
+    QUOTE_EXPIRY_SECONDS,
     RATE_LIMIT_QUOTE,
     SENTRY_DSN,
     STRIPE_SECRET_KEY,
@@ -39,7 +43,7 @@ if SENTRY_DSN:
     )
     logging.captureWarnings(True)  # Route warnings.warn() through logging so Sentry sees them
 
-from ingestion_api.database import get_db
+from ingestion_api.database import SessionLocal, get_db
 from ingestion_api.models import (
     CategorisedPrompt,
     Edition,
@@ -78,6 +82,8 @@ app.add_middleware(
 @app.on_event("startup")
 async def startup_event():
     """Log API startup for visibility in Cloud Logging & Sentry."""
+    global _cleanup_task
+    _cleanup_task = asyncio.create_task(_quote_cleanup_loop())
     configure_stripe()
     if not STRIPE_SECRET_KEY:
         logger.error(
@@ -103,6 +109,13 @@ async def startup_event():
     )
 
 
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Cancel background tasks on graceful shutdown."""
+    if _cleanup_task is not None:
+        _cleanup_task.cancel()
+
+
 @app.exception_handler(RateLimitExceeded)
 async def rate_limit_handler(request: Request, exc: RateLimitExceeded):
     logger.warning("Rate limit exceeded for %s", request.client)
@@ -120,6 +133,51 @@ async def general_exception_handler(request: Request, exc: Exception):
         status_code=500,
         content={"detail": "Internal server error"},
     )
+
+
+# --- Quote expiry cleanup ---
+
+
+def purge_expired_quotes(db, cutoff: datetime) -> int:
+    """Delete 'quoted' prompts older than *cutoff* and their category rows.
+
+    Returns the number of prompts purged.  Safe to call from tests.
+    """
+    expired_ids = [
+        p.id
+        for p in db.query(Prompt).filter(
+            Prompt.status == "quoted",
+            Prompt.created_at < cutoff,
+        ).all()
+    ]
+    if expired_ids:
+        db.query(CategorisedPrompt).filter(
+            CategorisedPrompt.prompt_id.in_(expired_ids)
+        ).delete(synchronize_session=False)
+        db.query(Prompt).filter(Prompt.id.in_(expired_ids)).delete(
+            synchronize_session=False
+        )
+        db.commit()
+        logger.info("Purged %d expired quoted prompt(s)", len(expired_ids))
+    return len(expired_ids)
+
+
+async def _quote_cleanup_loop() -> None:
+    """Background asyncio task: purge orphaned quotes on a fixed interval."""
+    while True:
+        await asyncio.sleep(QUOTE_CLEANUP_INTERVAL_SECONDS)
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=QUOTE_EXPIRY_SECONDS)
+        db = SessionLocal()
+        try:
+            purge_expired_quotes(db, cutoff)
+        except Exception:
+            logger.exception("Error during expired quote cleanup")
+            db.rollback()
+        finally:
+            db.close()
+
+
+_cleanup_task: asyncio.Task | None = None
 
 
 # --- Dependency: categoriser ---

--- a/apps/ingestion-api/tests/test_api.py
+++ b/apps/ingestion-api/tests/test_api.py
@@ -1,6 +1,7 @@
 """Integration tests for API endpoints."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 
@@ -405,6 +406,61 @@ def test_webhook_dispute_unknown_transaction(client):
     response = _post_webhook(client, event)
     assert response.status_code == 200
     assert "unknown transaction" in response.json()["detail"]
+
+
+# --- Quote expiry cleanup tests ---
+
+
+def test_purge_expired_quotes_removes_old_rows(client, db_session):
+    """Expired 'quoted' prompts should be deleted along with their category rows."""
+    from ingestion_api.main import purge_expired_quotes
+    from ingestion_api.models import CategorisedPrompt, Prompt
+
+    quote = _create_quote(client)
+    prompt = db_session.query(Prompt).filter_by(id=quote["quote_id"]).first()
+
+    # Back-date the prompt so it appears older than the expiry window.
+    prompt.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.commit()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    purged = purge_expired_quotes(db_session, cutoff)
+
+    assert purged == 1
+    assert db_session.query(Prompt).filter_by(id=quote["quote_id"]).first() is None
+    assert db_session.query(CategorisedPrompt).filter_by(prompt_id=quote["quote_id"]).count() == 0
+
+
+def test_purge_expired_quotes_keeps_recent_rows(client, db_session):
+    """Quotes created recently must not be purged."""
+    from ingestion_api.main import purge_expired_quotes
+    from ingestion_api.models import Prompt
+
+    _create_quote(client)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    purged = purge_expired_quotes(db_session, cutoff)
+
+    assert purged == 0
+    assert db_session.query(Prompt).count() == 1
+
+
+def test_purge_expired_quotes_skips_accepted_prompts(client, db_session):
+    """Accepted prompts must not be deleted even if old."""
+    from ingestion_api.main import purge_expired_quotes
+    from ingestion_api.models import Prompt
+
+    quote = _create_quote(client)
+    prompt = db_session.query(Prompt).filter_by(id=quote["quote_id"]).first()
+    prompt.status = "accepted"
+    prompt.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.commit()
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    purged = purge_expired_quotes(db_session, cutoff)
+
+    assert purged == 0
+    assert db_session.query(Prompt).filter_by(id=quote["quote_id"]).first() is not None
 
 
 def test_webhook_unknown_event_ignored(client):


### PR DESCRIPTION
Implements mitigations for #issue-29 (quote endpoint spam).

- Lower default rate limit from 10/min to 3/min per IP
- Add background cleanup that deletes orphaned `quoted` prompts older than 1 hour
- Three new unit tests covering the purge logic

Closes #29

Generated with [Claude Code](https://claude.ai/code)