### PR TITLE
fix: address pr #45 review comments

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -466,7 +466,7 @@ Go to **Secret Manager** in Google Cloud Console and create three secrets:
 | `r2-access-key-id`     | The Access Key ID from Step 3.3     |
 | `r2-secret-access-key` | The Secret Access Key from Step 3.3 |
 
-### 3.5a Store Tavily API Key in Google Cloud
+### 3.4a Store Tavily API Key in Google Cloud
 
 The News Scout uses [Tavily](https://tavily.com/) to search for real-world news. Store the API key in Secret Manager:
 
@@ -995,7 +995,7 @@ These are all the configuration values used by the backend services. Most are st
 | `MAX_BACKFILL_IMAGES_PER_RUN` | Env var | `20`                         | Max images to generate during the end-of-run backfill step for previously failed image generations                |
 | `NEWS_SCOUT_ENABLED`          | Env var | `true`                       | Set to `false` to disable the News Scout (no real-world news gap filling)                                         |
 | `TAVILY_RPM`                  | Env var | `99`                         | Maximum Tavily API requests per minute                                                                            |
-| `TAVILY_MONTHLY_LIMIT`        | Env var | `999`                        | Maximum Tavily API requests per month (cost safety net)                                                           |
+| `TAVILY_MONTHLY_LIMIT`        | Env var | `999`                        | Maximum Tavily API requests per month. **Production note:** the counter is stored in `/tmp` and resets on each Cloud Run container start, so this does not enforce a hard monthly cap in production. Use Tavily's own dashboard alerts for billing protection.                                                           |
 | `NEWS_ITEM_BASE_WEIGHT`       | Env var | `0.3`                        | Priority weight for news items in distillation (user prompts are 0.5–1.0+)                                       |
 | `NEWS_MUTATES_LEDGER`         | Env var | `true`                       | Whether news-only editions update the WorldLedger (set `true` at launch so the world evolves even with no users) |
 | `LOG_LEVEL`                   | Env var | `INFO`                       | Log verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`)                                                               |

--- a/apps/ingestion-api/ingestion_api/models.py
+++ b/apps/ingestion-api/ingestion_api/models.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ingestion_api.database import Base
@@ -105,6 +105,9 @@ class Edition(Base):
 
 class NewsItem(Base):
     __tablename__ = "news_items"
+    __table_args__ = (
+        UniqueConstraint("source_url", "edition_date", name="uq_news_items_url_date"),
+    )
 
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=_new_uuid

--- a/apps/newsroom-director/newsroom_director/main.py
+++ b/apps/newsroom-director/newsroom_director/main.py
@@ -57,7 +57,7 @@ if SENTRY_DSN:
         ],
     )
     logging.captureWarnings(True)  # Route warnings.warn() through logging so Sentry sees them
-from .config import NEWS_ITEM_BASE_WEIGHT, NEWS_MUTATES_LEDGER
+from .config import NEWS_ITEM_BASE_WEIGHT
 from .db import (
     NewsItemRecord,
     fetch_pending_news_items,
@@ -226,11 +226,11 @@ def run_morning_press(
                 extra={"surviving_prompts": len(prompt_records)},
             )
 
-        has_user_prompts = len(prompt_records) > 0
-
+        # Only reachable here when coherence validation rejected all prompts;
+        # the pre-validation check already handled the case with no prompts at all.
         if not prompt_records and not news_items:
             logger.info(
-                "All prompts rejected and no news items, skipping edition"
+                "All prompts rejected by coherence validation and no news items, skipping edition"
             )
             _run_backfill()
             return {
@@ -417,10 +417,9 @@ def run_morning_press(
                 )
 
         # Step 9: WorldLedger mutation via LLM
-        # Controlled by NEWS_MUTATES_LEDGER: when False, mutation only
-        # runs if at least one user prompt was processed in this edition.
-        should_mutate = articles and (has_user_prompts or NEWS_MUTATES_LEDGER)
-        if should_mutate:
+        # Always run when articles were generated — world news drives world state
+        # regardless of whether any user prompts were processed in this edition.
+        if articles:
             try:
                 mutation_system, mutation_content = _build_mutation_prompt(synopsis, articles)
                 mutation_response = gen.generate(mutation_system, "pro", mutation_content)
@@ -432,11 +431,6 @@ def run_morning_press(
                 logger.exception(
                     "WorldLedger mutation failed, skipping world state update"
                 )
-        elif articles and not has_user_prompts:
-            logger.info(
-                "Skipping WorldLedger mutation — no user prompts and "
-                "NEWS_MUTATES_LEDGER=false"
-            )
 
         # Step 9b: Image generation — parse article JSON, generate images,
         # embed image URLs back into the content.

--- a/apps/newsroom-director/newsroom_director/news_scout/main.py
+++ b/apps/newsroom-director/newsroom_director/news_scout/main.py
@@ -29,6 +29,7 @@ from ..db import (
 )
 from ..generation import GenerationStrategy, StubGenerationStrategy, VertexAIStrategy
 from ..logging_config import configure_logging
+from ..personas import NEWSPAPER_PERSONAS
 from ..taxonomy import CATEGORY_IDS
 from ..world_ledger import INITIAL_WORLD_LEDGER, serialize_ledger_to_synopsis
 from ..world_ledger.serialise_dict import ledger_from_dict
@@ -87,7 +88,7 @@ def run_news_scout(
             "Generating search queries",
             extra={"step": "news_scout_generate", "category_count": len(CATEGORY_IDS)},
         )
-        queries_by_category = generate_queries(synopsis, CATEGORY_IDS, gen)
+        queries_by_category = generate_queries(synopsis, CATEGORY_IDS, gen, NEWSPAPER_PERSONAS)
 
         if not queries_by_category:
             logger.warning("No queries generated, exiting News Scout")

--- a/apps/newsroom-director/newsroom_director/news_scout/main.py
+++ b/apps/newsroom-director/newsroom_director/news_scout/main.py
@@ -55,7 +55,6 @@ def run_news_scout(
     Returns:
         Summary dict with counts of queries executed and items stored.
     """
-    configure_logging()
     start_time = time.monotonic()
 
     db_url = database_url or DATABASE_URL

--- a/apps/newsroom-director/newsroom_director/news_scout/query_generator.py
+++ b/apps/newsroom-director/newsroom_director/news_scout/query_generator.py
@@ -8,6 +8,7 @@ world would find editorially interesting right now.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from ..generation import GenerationStrategy
 from .schemas import (
@@ -16,26 +17,37 @@ from .schemas import (
     parse_query_output,
 )
 
+if TYPE_CHECKING:
+    from ..personas import PersonaConfig
+
 logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = """\
-You are the chief intelligence officer for a fictional world newspaper. \
+You are the chief intelligence officer for a fictional world newspaper group. \
 Your job is to commission search queries that will surface the most \
-editorially consequential real-world news for today's edition.
+editorially consequential real-world news for today's editions across \
+all newspapers in the group.
 
-You have two inputs:
+You have three inputs:
 1. A synopsis of the fictional world's current state — nations, conflicts, \
 alliances, economic trends, technological developments, cultural movements, \
 and environmental crises.
-2. A set of editorial categories that the newspaper covers.
+2. A set of editorial categories that the newspapers collectively cover.
+3. The editorial identities of the newspapers — their ideologies, political \
+leanings, and areas of focus — so you can tailor queries to what each \
+readership finds most compelling.
 
 Your reasoning process:
 - Identify which fictional world threads have real-world analogues or \
 parallels that could enrich the narrative (e.g. a fictional energy scarcity \
 crisis maps to real-world energy market disruptions).
-- For each category, decide which specific real-world developments a \
-discerning editor would find most valuable RIGHT NOW — not trending stories, \
-but stories with genuine narrative depth and geopolitical weight.
+- For each category, consider which newspapers subscribe to it and what \
+angle their readership would find most valuable — a geopolitical category \
+read by a conservative-leaning paper demands different query framing than \
+the same category read by a progressive one.
+- Decide which specific real-world developments a discerning editor would \
+find most valuable RIGHT NOW — not trending stories, but stories with \
+genuine narrative depth and geopolitical weight.
 - Formulate queries that cut through noise: prefer named actors, specific \
 regions, concrete events, and verifiable timelines over broad topic searches.
 - Where the world synopsis signals active tension or change in a domain, \
@@ -64,10 +76,22 @@ vague ones."""
 MAX_RETRIES = 3
 
 
+def _format_personas(personas: list[PersonaConfig]) -> str:
+    """Format persona definitions as a compact editorial roster."""
+    lines = []
+    for p in personas:
+        lines.append(
+            f"- {p.paper_name} ({p.id}): {p.ideology} | {p.political_leaning} | "
+            f"categories: {', '.join(p.subscribed_categories)}"
+        )
+    return "\n".join(lines)
+
+
 def generate_queries(
     synopsis: str,
     category_ids: list[str],
     generation_strategy: GenerationStrategy,
+    personas: list[PersonaConfig] | None = None,
 ) -> dict[str, list[str]]:
     """Generate search queries for each category based on the WorldLedger.
 
@@ -75,14 +99,22 @@ def generate_queries(
         synopsis: Serialized WorldLedger synopsis text.
         category_ids: All 30 taxonomy category slugs.
         generation_strategy: LLM backend (Gemini Flash).
+        personas: Newspaper persona configs so the model knows which
+            editorial identities will consume each category's articles.
 
     Returns:
         Dict mapping category_id to list of search query strings.
         May be empty if all attempts fail.
     """
     category_list = "\n".join(f"- {cid}" for cid in category_ids)
+    personas_section = (
+        f"\nNEWSPAPER PERSONAS:\n{_format_personas(personas)}\n"
+        if personas
+        else ""
+    )
     user_content = (
-        f"WORLD STATE SYNOPSIS:\n{synopsis}\n\n"
+        f"WORLD STATE SYNOPSIS:\n{synopsis}\n"
+        f"{personas_section}\n"
         f"CATEGORIES:\n{category_list}\n\n"
         "Generate search queries for each category."
     )

--- a/apps/newsroom-director/newsroom_director/news_scout/query_generator.py
+++ b/apps/newsroom-director/newsroom_director/news_scout/query_generator.py
@@ -19,23 +19,33 @@ from .schemas import (
 logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = """\
-You are a news editor for a fictional newspaper simulation. You have access \
-to the current state of the world (provided below) and a list of 30 editorial \
+You are the chief intelligence officer for a fictional world newspaper. \
+Your job is to commission search queries that will surface the most \
+editorially consequential real-world news for today's edition.
+
+You have two inputs:
+1. A synopsis of the fictional world's current state — nations, conflicts, \
+alliances, economic trends, technological developments, cultural movements, \
+and environmental crises.
+2. A set of editorial categories that the newspaper covers.
+
+Your reasoning process:
+- Identify which fictional world threads have real-world analogues or \
+parallels that could enrich the narrative (e.g. a fictional energy scarcity \
+crisis maps to real-world energy market disruptions).
+- For each category, decide which specific real-world developments a \
+discerning editor would find most valuable RIGHT NOW — not trending stories, \
+but stories with genuine narrative depth and geopolitical weight.
+- Formulate queries that cut through noise: prefer named actors, specific \
+regions, concrete events, and verifiable timelines over broad topic searches.
+- Where the world synopsis signals active tension or change in a domain, \
+generate 3 precise queries. For stable domains, 1-2 well-targeted queries \
+are enough.
+- Include temporal anchors (e.g. "March 2026", "Q1 2026", "this month") \
+where recency matters.
+- Avoid: generic news queries ("latest X news"), celebrity/entertainment \
+unless the category demands it, queries duplicating each other across \
 categories.
-
-Your task: for each category, generate 2-3 targeted web search queries that \
-would find current real-world news stories relevant to that category. Think \
-about what developments would be most editorially interesting given the world \
-state — not what is most popular or trending, but what a thoughtful journalist \
-would want to investigate.
-
-Guidelines:
-- Queries should be specific enough to return focused results (not generic \
-like "latest news").
-- Include date/time references where useful (e.g. "March 2026", "this week").
-- For categories where the world state suggests active developments, generate \
-3 queries. For quieter domains, 1-2 is fine.
-- Each query should be a natural search engine query string.
 
 You MUST respond with a JSON object matching this exact schema:
 {
@@ -47,7 +57,9 @@ You MUST respond with a JSON object matching this exact schema:
   ]
 }
 
-Include ALL provided category IDs in the output, each with at least 1 query."""
+Include ALL provided category IDs. Every category must have at least 1 query. \
+Prioritise quality over quantity — a single razor-sharp query beats three \
+vague ones."""
 
 MAX_RETRIES = 3
 
@@ -79,7 +91,7 @@ def generate_queries(
         try:
             raw = generation_strategy.generate(
                 _SYSTEM_PROMPT,
-                "flash",
+                "pro",
                 user_content,
                 response_schema=QueryGenerationOutput,
             )


### PR DESCRIPTION
Addresses code review comments from PR #45 (add news scout).

- Always mutate WorldLedger when articles are generated (world news drives world state regardless of user prompts)
- Upgrade news scout query generator to pro model with improved editorial reasoning prompt
- Add UniqueConstraint to NewsItem ORM model to match migration
- Remove duplicate configure_logging() call in run_news_scout()
- Fix DEPLOYMENT.md section numbering (3.5a → 3.4a)
- Document TAVILY_MONTHLY_LIMIT production limitation

Generated with [Claude Code](https://claude.ai/code)